### PR TITLE
Make cachix auth token lookup in onepassword only occur when unset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -519,7 +519,9 @@
               ];
 
               shellHook = ''
-                CACHIX_AUTH_TOKEN=''$(${pkgs._1password-cli}/bin/op item get "Cachix Token" --fields label=password --reveal)
+                if [ -z ''${var+x} ]; then 
+                  CACHIX_AUTH_TOKEN=''$(${pkgs._1password-cli}/bin/op item get "Cachix Token" --fields label=password --reveal)
+                fi
               '';
             };
           };


### PR DESCRIPTION
So that it doesn't fail in Github actions pipelines.