### PR TITLE
chore(deps): bump terraform-ls-rs to v0.2.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -351,11 +351,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780430507,
-        "narHash": "sha256-mbsxGYVY9wz2H6NuzSrRKJniZSOMBebdHYg/YHJWYeQ=",
+        "lastModified": 1780486251,
+        "narHash": "sha256-a/HUPjrKghK0tEGMDZXXNUOG19Ffv3ZAvrd1jC83m7s=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "e271061ebb1b80a7522eaaf09976feccbf742006",
+        "rev": "3400fda5e09009904bf7f1a29ed4eb7b0734c075",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Updates the `terraform-ls-rs` flake input to **v0.2.2** (rev `3400fda`).

## What this pulls in

terraform-ls-rs v0.2.2 bumps its `tf-format` formatting backend to **v0.4.4**:
- preserve `<<-` heredoc markers dropped by hcl-edit (tf-format #43)
- tidy blank lines in arrays and before closing braces (tf-format #35)

## Verification

`nix build` of the terraform-ls-rs package from the locked rev succeeds — produces `tfls 0.2.2`, built against tf-format `a6f96e28` (v0.4.4). Only the `terraform-ls-rs` input changed in `flake.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)