### PR TITLE
chore(deps): pin terraform-ls-rs to v0.7.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,15 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780781789,
-        "narHash": "sha256-rbbhlBugSIY8c29t5ZnDBi3LAuDgOd8SzJROgymxOIk=",
+        "lastModified": 1780947677,
+        "narHash": "sha256-9CFeu312TuqG1kiMNNfwFkWO5U7h4ntmYjQjZtlWZdw=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "c94f56023bb1da0fb35056760f60c3c745729805",
+        "rev": "a15c84d201f397f19fa623ac0d60421d769235d5",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
+        "ref": "v0.7.1",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.7.1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Pins the terraform-ls-rs LSP input to the **v0.7.1** release tag (was tracking the default branch).

v0.7.1 ships:
- tf-format **0.4.7** formatter fix — multi-line attributes (`tags = merge(...)`) no longer keep stale `=` alignment from a prior single-line value
- the first tag with a `Cargo.lock` consistent with its version, so it builds under `--locked` via this flake (earlier tags broke crane/Nix `--locked` builds)

Verified: `nix build .#terraform-ls-rs` (via the input) → `terraform-ls-rs-0.7.1` builds clean.

Note: `nix build .#default` currently fails on an **unrelated** upstream hash drift in `kulala.nvim`'s npm deps (`kulala-core-node_modules`), not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)