### PR TITLE
fix(kulala): pin corrected kulala-core node_modules hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1597,6 +1597,22 @@ p.write_text(src.replace(old, '\n'.join(new_lines)))
                   };
                 };
               })
+              # nixpkgs (pinned rev, 2026-06-06) ships kulala-core 0.13.0 with a
+              # stale node_modules `outputHash` — its `bun install` FOD produces
+              # a different tree than the recorded hash, so the build fails:
+              #   specified: sha256-NjHm6KU6Cd0ZyL1c+bmNbEHb5E83/xjQ5UGRjY1hzgQ=
+              #   got:       sha256-XQlBawD3vt8pVc7Gy9XeiGie89HWbljNJt7kUEDaDKk=
+              # kulala-core is a dependency of vimPlugins.kulala-nvim, so this
+              # breaks `nix build .#default`. Pin the node_modules hash to what
+              # this nixpkgs' bun actually produces. Drop once nixpkgs corrects
+              # it (https://github.com/NixOS/nixpkgs by-name/ku/kulala-core).
+              (_final: prev: {
+                kulala-core = prev.kulala-core.overrideAttrs (old: {
+                  node_modules = old.node_modules.overrideAttrs (_: {
+                    outputHash = "sha256-XQlBawD3vt8pVc7Gy9XeiGie89HWbljNJt7kUEDaDKk=";
+                  });
+                });
+              })
             ];
           };
 


### PR DESCRIPTION
The pinned nixpkgs (2026-06-06) ships kulala-core 0.13.0 with a stale node_modules `outputHash` — its `bun install` FOD produces a different tree than recorded, so the build fails:

```
specified: sha256-NjHm6KU6Cd0ZyL1c+bmNbEHb5E83/xjQ5UGRjY1hzgQ=
got:       sha256-XQlBawD3vt8pVc7Gy9XeiGie89HWbljNJt7kUEDaDKk=
```

kulala-core is a dependency of `vimPlugins.kulala-nvim`, which broke `nix build .#default`. Overlay-override the node_modules `outputHash` to the value this nixpkgs' bun actually produces.

Verified: `nix build .#default` → `nixvim` builds clean.

Drop once nixpkgs corrects the upstream hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)