### PR TITLE
chore(deps): pin terraform-ls-rs to v0.8.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780947677,
-        "narHash": "sha256-9CFeu312TuqG1kiMNNfwFkWO5U7h4ntmYjQjZtlWZdw=",
+        "lastModified": 1780957254,
+        "narHash": "sha256-1k0i6psY4v7eUh982o762i+lCYZwx/UHncQVsutSOQ8=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "a15c84d201f397f19fa623ac0d60421d769235d5",
+        "rev": "3b0f3bdd8427c65521db24b5742b8e71a09d34f3",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.7.1",
+        "ref": "v0.8.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.7.1";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.8.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Pins the LSP to **v0.8.0**, which adds the git module ref pinning feature:

- Diagnostics: `terraform_module_mutable_ref` (tag/branch ref), `terraform_module_ref_tag_mismatch` (tag re-pointed off the pinned SHA), `terraform_module_outdated` (newer tag available).
- Code actions: pin ref → SHA (+ `# tag` comment), add tag comment to a SHA pin, mismatch dual-fix, switch version. SSH sources resolve via the user's keys; monorepo per-module tags handled.

Verified: `nix build .#terraform-ls-rs` → `terraform-ls-rs-0.8.0`, and `nix build .#default` → `nixvim` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)