### PR TITLE
chore(deps): pin terraform-ls-rs to v0.9.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1780957254,
-        "narHash": "sha256-1k0i6psY4v7eUh982o762i+lCYZwx/UHncQVsutSOQ8=",
+        "lastModified": 1781129953,
+        "narHash": "sha256-uik8gfxfvxhALp8G0CFqHivo/VadTYhVCUz7HO6qp44=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "3b0f3bdd8427c65521db24b5742b8e71a09d34f3",
+        "rev": "d19b7619594c14819b824fb6b94cd58d7df25979",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.8.0",
+        "ref": "v0.9.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.8.0";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.9.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input from `v0.8.0` → `v0.9.0` (latest release).

- `flake.nix`: pin `v0.8.0` → `v0.9.0`
- `flake.lock`: input rev `3b0f3bd` → `d19b761`

Verified: `nix build github:alisonjenkins/terraform-ls-rs/v0.9.0#packages.x86_64-linux.default` builds clean (`terraform-ls-rs-0.9.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)