### PR TITLE
chore(deps): pin terraform-ls-rs to v0.11.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781305803,
-        "narHash": "sha256-w7jk50C7RTDTV1J62P80zO2Iyev2IeTb6Su7wA/1kg0=",
+        "lastModified": 1781678841,
+        "narHash": "sha256-O/WTvzNKoyXRtjuEUuuE5BuUBtAq4yzJ6nmRSPRMsiA=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "99fd6fb3fced45de1e4a909dea68e11cd14ae846",
+        "rev": "6edd26e22d1a0067ec2f6da2b7f1c1c3cfcba4b3",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.10.0",
+        "ref": "v0.11.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.10.0";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.11.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input from v0.10.0 to v0.11.0.

terraform-ls-rs 0.11.0 bundles tf-format v0.4.8, picking up the opinionated-formatter fixes:
- hoist dynamic-block `for_each`/`iterator`/`labels` before `content` (tf-format #55)
- strip trailing commas from multi-line map entries (tf-format #54)
- keep inline comments on comma-terminated object entries (tf-format #53)

Verified locally: `nix build` of the pinned rev produces `tfls 0.11.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)