### PR TITLE
chore(deps): bump terraform-ls-rs to v0.11.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781791171,
-        "narHash": "sha256-Nj1ibp82cXLUJcyBN1QfPVrwHcoFkpqj8I4cE2ofcFc=",
+        "lastModified": 1781798655,
+        "narHash": "sha256-d/+kPIpFhTzexfMkTNVxgwe72wNNv6v09jOgY4G2bns=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "e383100d18106bc823fc2c553587edb1fc4d7652",
+        "rev": "1e3b44e373c1665d9696cf4255bd0c89dc89fa3a",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.11.3",
+        "ref": "v0.11.4",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.11.3";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.11.4";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input v0.11.3 → v0.11.4, which pulls in **tf-format v0.4.9**.

v0.4.9 aligns trailing inline comments by column (matching `tofu fmt`), so the Terraform language server no longer flags otherwise-formatted files as needing formatting.

Verified locally:
- `.#nvim` drv graph evaluates clean.
- `terraform-ls-rs v0.11.4` builds under Nix (`--locked` / crane), bundling tf-format commit `9545522` (v0.4.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)