### PR TITLE
chore(deps): bump terraform-ls-rs to v0.12.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781851636,
-        "narHash": "sha256-M5vfxWtdG7RgmkjtNCilphoiooFn8vGqURT0TrLML68=",
+        "lastModified": 1781855252,
+        "narHash": "sha256-J+ppZbGqZEcHjP+cDD8Zl9AuulXC6tQvka9yFfIwCZA=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "1956b1e8162f83b6c9db733ea21d1d7c35125e7c",
+        "rev": "f3dd3f8b246737552a768e7bfd10a1b6c6668bf8",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.12.0",
+        "ref": "v0.12.1",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.12.0";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.12.1";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input v0.12.0 → v0.12.1, pulling in **tf-format v0.4.10**.

tf-format v0.4.10 (exploratory-testing batch):
- 🔴 no longer refuses valid files on benign whitespace normalization (misleading duplicate-keys error — harmful on format-on-type).
- aligns multi-line array element trailing comments.
- single-line array trailing-comma `, ]` form.
- unwraps redundant attribute-value interpolation (`a = "${foo}"` → `a = foo`).

Verified: `.#nvim` evaluates; `terraform-ls-rs v0.12.1` builds under Nix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)