### PR TITLE
fix(sidekick): set nes.enabled at correct settings path

### DIFF
--- a/plugin-config/sidekick/default.nix
+++ b/plugin-config/sidekick/default.nix
@@ -6,10 +6,8 @@ in
     enable = true;
 
     settings = {
-      opts = {
-        nes = {
-          enabled = config.nesEnabled;
-        };
+      nes = {
+        enabled = config.nesEnabled;
       };
 
       keys = { };


### PR DESCRIPTION
nixvim's sidekick module reads `settings.nes.enabled` for its copilot-requirement assertion, but the config nested it under `settings.opts.nes`. So `settings.nes.enabled` stayed at its default (`true`), tripping the assertion that NES requires copilot-lua/copilot LSP even though NES is meant to be disabled. A recent nixvim bump on `nixos-26.05` added that assertion, breaking all downstream evals (e.g. nix-config's `ali-desktop`).

Unwrap the `opts` layer so `nes.enabled` lands where both the assertion and sidekick.nvim's setup read it. `nix eval .#packages.x86_64-linux.nvim.drvPath` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)