### PR TITLE
chore: bump terraform-ls-rs to v0.14.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1781972625,
-        "narHash": "sha256-SE3408GgqufIP8nZAGiTh1foMhm572tKKlqklVDVGEI=",
+        "lastModified": 1782371578,
+        "narHash": "sha256-W34tYC/Jfd9FGUQ0AkfnLLfEOhjgO3S95+krs5sN2mc=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "76bbad4301c07a88721048ea987539e6d0857f9d",
+        "rev": "1fef317f1b732375672d250a7061eef055292724",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.13.2",
+        "ref": "v0.14.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.13.2";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.14.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bump `terraform-ls-rs` flake input from `v0.13.2` to `v0.14.0`.

## terraform-ls-rs v0.14.0
Release: https://github.com/alisonjenkins/terraform-ls-rs/releases/tag/v0.14.0

### Features
- **diag:** add missing-tags and missing-name-tag diagnostics
- **lsp:** wire missing-tags diagnostics with default_tags suppression

## Changes
- `flake.nix` — input url `v0.13.2` → `v0.14.0`
- `flake.lock` — re-locked terraform-ls-rs to commit `1fef317` (tag v0.14.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)