### PR TITLE
chore: bump terraform-ls-rs to v0.15.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782371578,
-        "narHash": "sha256-W34tYC/Jfd9FGUQ0AkfnLLfEOhjgO3S95+krs5sN2mc=",
+        "lastModified": 1782389549,
+        "narHash": "sha256-DSOHXUZU3ND0J73M5YYtf+OqATRROAc5G1rT4uMzUSA=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "1fef317f1b732375672d250a7061eef055292724",
+        "rev": "46fceee405d6c2b6c6c160ed3b88908d5bc36499",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.14.0",
+        "ref": "v0.15.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.14.0";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.15.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input from v0.14.0 → v0.15.0.

v0.15.0 ships two false-`terraform_undefined_reference` fixes:
- **cross-file refs across symlinked module dirs** — `location_in_dir` now compares parent dirs symlink-tolerantly, so sibling-declared `var.*`/`local.*`/`module.*` resolve when the workspace root is symlinked (e.g. macOS `/var`→`/private/var`).
- **same-file locals flashing undefined during rapid reparse** — the resolver consults the doc's own symbol table before the global index, closing a concurrent-reparse race.

`nix flake update terraform-ls-rs` re-locked to tag commit `46fceee`. Sanity eval:
```
nix eval --raw 'github:alisonjenkins/terraform-ls-rs/v0.15.0#packages.aarch64-darwin.default.drvPath'
→ /nix/store/...-terraform-ls-rs-0.15.0.drv
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)