### PR TITLE
chore: bump terraform-ls-rs to v0.16.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -337,16 +337,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1782389549,
-        "narHash": "sha256-DSOHXUZU3ND0J73M5YYtf+OqATRROAc5G1rT4uMzUSA=",
+        "lastModified": 1782884198,
+        "narHash": "sha256-ojCOMkX4W+/XL03ZwfCEhhLzVr/S5PuBVdAm2Plb85k=",
         "owner": "alisonjenkins",
         "repo": "terraform-ls-rs",
-        "rev": "46fceee405d6c2b6c6c160ed3b88908d5bc36499",
+        "rev": "f96c71c0426ee249d8ed41932955b33af835370a",
         "type": "github"
       },
       "original": {
         "owner": "alisonjenkins",
-        "ref": "v0.15.0",
+        "ref": "v0.16.0",
         "repo": "terraform-ls-rs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
     # nixvim.url = "github:alisonjenkins/nixvim/fix/sidekick-nes-disabled";
     terraform-ls-rs = {
-      url = "github:alisonjenkins/terraform-ls-rs/v0.15.0";
+      url = "github:alisonjenkins/terraform-ls-rs/v0.16.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
Bumps the `terraform-ls-rs` flake input v0.13.2 → v0.16.0 (rev `f96c71c`, tag built in the upstream `release.yml` CI).

`flake.nix` pin + `flake.lock` node only. Unrelated in-tree `sidekick/default.nix` change left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)